### PR TITLE
Fix: Use of deprecated Pandas method, mis-matched S3 prefixes; Added info on obtaining training images for other regions

### DIFF
--- a/content/builtin/parallelized.md
+++ b/content/builtin/parallelized.md
@@ -169,6 +169,7 @@ In this section, you will learn about how to take full advantage of distributed 
       - Oregon:  174872318107.dkr.ecr.us-west-2.amazonaws.com/linear-learner:latest
       - Ohio:  404615174143.dkr.ecr.us-east-2.amazonaws.com/linear-learner:latest
       - Ireland:  438346466558.dkr.ecr.eu-west-1.amazonaws.com/linear-learner:latest
+      - For other regions, see [this](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html)
 
   - For the 'Location of model artifacts' field under **Primary Container**, enter the path to the output of your replicated training job.  To find the path, go back to your first browser tab, click **Jobs** in the left pane, then find and click the replicated job name, which will look like `linear-replicated-<date>`.  Scroll down to the **Outputs** section, then copy the path under 'S3 model artifact'.  Paste the path in the field; it should look like `s3://sagemaker-projects-pdx/sagemaker/data_distribution_types/linear-replicated-2018-03-11-18-13-13/output/model.tar.gz`.  
 

--- a/content/builtin/parallelized.md
+++ b/content/builtin/parallelized.md
@@ -71,7 +71,7 @@ In this section, you will learn about how to take full advantage of distributed 
     bucket=<name-of-your-s3-bucket>
     region=<your-region>
 
-    prefix=/sagemaker/data_distribution_types
+    prefix=/sagemaker/DEMO-data-distribution-types
     training_job_name=linear-replicated-`date '+%Y-%m-%d-%H-%M-%S'`
 
     training_data=$bucket$prefix/train
@@ -125,7 +125,7 @@ In this section, you will learn about how to take full advantage of distributed 
     bucket=<name-of-your-s3-bucket>
     region=<your-region>
 
-    prefix=/sagemaker/data_distribution_types
+    prefix=/sagemaker/DEMO-data-distribution-types
     training_job_name=linear-sharded-`date '+%Y-%m-%d-%H-%M-%S'`
 
     training_data=$bucket$prefix/train

--- a/content/builtin/xgboost.md
+++ b/content/builtin/xgboost.md
@@ -57,6 +57,7 @@ This section also shows how to use SageMaker's built-in algorithms via hosted Ju
       - Oregon:  433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:latest
       - Ohio:  825641698319.dkr.ecr.us-east-2.amazonaws.com/xgboost:latest
       - Ireland:  685385470294.dkr.ecr.eu-west-1.amazonaws.com/xgboost:latest
+      - For other regions, see [this](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html)
 
   - **bucket**:  the name of the S3 bucket you used in your notebook.  It should look like:  `s3://smworkshop-john-smith`.
 

--- a/static/notebooks/data_distribution_types.ipynb
+++ b/static/notebooks/data_distribution_types.ipynb
@@ -210,7 +210,7 @@
     "def prepare_gdelt(bucket, prefix, file_prefix, events=None, random_state=1729):\n",
     "    df = get_gdelt(file_prefix + '.csv')\n",
     "    model_data = transform_gdelt(df, events)\n",
-    "    train_data, validation_data = np.split(model_data.sample(frac=1, random_state=random_state).as_matrix(), \n",
+    "    train_data, validation_data = np.split(model_data.sample(frac=1, random_state=random_state).values, \n",
     "                                           [int(0.9 * len(model_data))])\n",
     "    write_to_s3(bucket, prefix, 'train', file_prefix, train_data[:, 1:], train_data[:, 0])\n",
     "    write_to_s3(bucket, prefix, 'validation', file_prefix, validation_data[:, 1:], validation_data[:, 0])"
@@ -620,7 +620,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_data = transform_gdelt(get_gdelt('1984.csv'), events).as_matrix()\n",
+    "test_data = transform_gdelt(get_gdelt('1984.csv'), events).values\n",
     "test_X = test_data[:, 1:]\n",
     "test_y = test_data[:, 0]"
    ]

--- a/static/notebooks/image-classification-fulltraining.ipynb
+++ b/static/notebooks/image-classification-fulltraining.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "* The roles used to give learning and hosting access to your data. This will automatically be obtained from the role used to start the notebook\n",
     "* The S3 bucket that you want to use for training and model data\n",
-    "* The Amazon sagemaker image classification docker image which need not be changed"
+    "* The Amazon sagemaker image classification docker image which need not be changed (for other regions, see [this](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html))"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

 - Fix: `.as_matrix()` replaced with `.values` since `.as_matrix()` is deprecated for a Pandas DataFrame
 - Fix: S3 prefixes in notebook and scripts updated to match (in Parallelized Data Distribution)
 - Added information on where to obtain training images in regions other than the 4 specified

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
